### PR TITLE
The gpt pointer is not initialized, and when offset < 0, it may resul…

### DIFF
--- a/GRUB2/MOD_SRC/grub-2.04/grub-core/ventoy/ventoy_vhd.c
+++ b/GRUB2/MOD_SRC/grub-2.04/grub-core/ventoy/ventoy_vhd.c
@@ -504,7 +504,7 @@ grub_err_t ventoy_cmd_get_vtoy_type(grub_extcmd_context_t ctxt, int argc, char *
     vhd_footer_t vhdfoot;
     VDIPREHEADER vdihdr;
     char type[16] = {0};
-    ventoy_gpt_info *gpt;
+    ventoy_gpt_info *gpt = NULL;
     
     (void)ctxt;
 


### PR DESCRIPTION
…t in freeing unallocated memory.