### PR TITLE
CI + Dockerfile + scripts: bug fixes, dep bumps, and cleanups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,16 @@ jobs:
         key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
         restore-keys: |
           ${{ runner.os }}-buildx-
+    - name: Build Docker image with cache
+      run: |
+        docker buildx build \
+          --cache-from type=local,src=/tmp/.buildx-cache \
+          --cache-to type=local,dest=/tmp/.buildx-cache-new,mode=max \
+          --load -t ventoy-ventoy .
+        rm -rf /tmp/.buildx-cache
+        mv /tmp/.buildx-cache-new /tmp/.buildx-cache
     - name: Run docker compose up
-      run: docker compose up --build
+      run: docker compose up
     - uses: actions/upload-artifact@v4
       with:
         name: ventoy-windows

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+    - name: Cache Docker layers
+      uses: actions/cache@v4
+      with:
+        path: /tmp/.buildx-cache
+        key: ${{ runner.os }}-buildx-${{ hashFiles('Dockerfile') }}
+        restore-keys: |
+          ${{ runner.os }}-buildx-
     - name: Run docker compose up
-      run: docker compose up
+      run: docker compose up --build
     - uses: actions/upload-artifact@v4
       with:
         name: ventoy-windows

--- a/.github/workflows/sync2gitee.yml
+++ b/.github/workflows/sync2gitee.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Mirror the Github repos to Gitee.
-      uses: Yikun/hub-mirror-action@master
+      uses: Yikun/hub-mirror-action@v1.5
       with:
         src: github/ventoy
         dst: gitee/LongPanda

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ RUN sed -i \
         mpfr.i686 mpfr-devel.i686 rsync autogen autoconf automake libtool gettext* bison binutils \
         flex device-mapper-devel SDL libpciaccess libusb freetype freetype-devel gnu-free-* qemu-* virt-* \
         libvirt* vte* NetworkManager-bluetooth brlapi fuse-devel dejavu* gnu-efi* pesign shim \
-        iscsi-initiator-utils grub2-tools zip nasm acpica-tools glibc-static zlib-static xorriso lz4 squashfs-tools
+        iscsi-initiator-utils grub2-tools zip nasm acpica-tools glibc-static zlib-static xorriso lz4 squashfs-tools && \
+    yum clean all && \
+    rm -rf /var/cache/yum
 
-CMD cd /ventoy/INSTALL && ls -la && sh docker_ci_build.sh    
+WORKDIR /ventoy/INSTALL
+CMD ls -la && sh docker_ci_build.sh

--- a/ExFAT/buidexfat.sh
+++ b/ExFAT/buidexfat.sh
@@ -6,7 +6,7 @@
 #
 #
 
-if uname -a | egrep -q 'x86_64|amd64'; then
+if uname -a | grep -E -q 'x86_64|amd64'; then
     opt=
 else
     opt=-lrt

--- a/FUSEISO/build.sh
+++ b/FUSEISO/build.sh
@@ -4,7 +4,7 @@ CUR="$PWD"
 
 LIBFUSE_DIR=$CUR/LIBFUSE
 
-if uname -a | egrep -q 'x86_64|amd64'; then
+if uname -a | grep -E -q 'x86_64|amd64'; then
     name=vtoy_fuse_iso_64
 else
     name=vtoy_fuse_iso_32
@@ -27,6 +27,4 @@ if [ -e $name ]; then
 else
     echo -e "\n############### FAILED $name ##################\n"
 fi
-
-strip --strip-all $name
 

--- a/GRUB2/MOD_SRC/grub-2.04/install.sh
+++ b/GRUB2/MOD_SRC/grub-2.04/install.sh
@@ -61,7 +61,7 @@ if [ "$1" = "uefi" ]; then
     cp -a $VT_DIR/GRUB2/PXE/grub2/x86_64-efi/normal.mod    $VT_DIR/INSTALL/grub/x86_64-efi/normal.mod  || exit 1      
 
     #copy other modules
-    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/x86_64-efi/ | egrep '\.(lst|mod)$' | while read line; do
+    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/x86_64-efi/ | grep -E '\.(lst|mod)$' | while read line; do
         if ! echo $all_modules | grep -q " ${line%.mod} "; then
             echo "Copy $line ..."
             cp -a $VT_DIR/GRUB2/INSTALL/lib/grub/x86_64-efi/$line    $VT_DIR/INSTALL/grub/x86_64-efi/
@@ -77,7 +77,7 @@ elif [ "$1" = "i386efi" ]; then
     cp -a $VT_DIR/GRUB2/PXE/grub2/i386-efi/normal.mod    $VT_DIR/INSTALL/grub/i386-efi/normal.mod  || exit 1      
 
     #copy other modules
-    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/i386-efi/ | egrep '\.(lst|mod)$' | while read line; do
+    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/i386-efi/ | grep -E '\.(lst|mod)$' | while read line; do
         if ! echo $all_modules | grep -q " ${line%.mod} "; then
             echo "Copy $line ..."
             cp -a $VT_DIR/GRUB2/INSTALL/lib/grub/i386-efi/$line    $VT_DIR/INSTALL/grub/i386-efi/
@@ -93,7 +93,7 @@ elif [ "$1" = "arm64" ]; then
     cp -a $VT_DIR/GRUB2/PXE/grub2/arm64-efi/normal.mod    $VT_DIR/INSTALL/grub/arm64-efi/normal.mod  || exit 1      
 
     #copy other modules
-    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/arm64-efi/ | egrep '\.(lst|mod)$' | while read line; do
+    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/arm64-efi/ | grep -E '\.(lst|mod)$' | while read line; do
         if ! echo $all_modules | grep -q " ${line%.mod} "; then
             echo "Copy $line ..."
             cp -a $VT_DIR/GRUB2/INSTALL/lib/grub/arm64-efi/$line    $VT_DIR/INSTALL/grub/arm64-efi/
@@ -111,7 +111,7 @@ elif [ "$1" = "mips64el" ]; then
     cp -a $VT_DIR/GRUB2/PXE/grub2/mips64el-efi/normal.mod    $VT_DIR/INSTALL/grub/mips64el-efi/normal.mod  || exit 1      
 
     #copy other modules
-    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/mips64el-efi/ | egrep '\.(lst|mod)$' | while read line; do
+    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/mips64el-efi/ | grep -E '\.(lst|mod)$' | while read line; do
         if ! echo $all_modules | grep -q " ${line%.mod} "; then
             echo "Copy $line ..."
             cp -a $VT_DIR/GRUB2/INSTALL/lib/grub/mips64el-efi/$line    $VT_DIR/INSTALL/grub/mips64el-efi/
@@ -127,7 +127,7 @@ else
     cp -a $VT_DIR/GRUB2/INSTALL/lib/grub/i386-pc/boot.img  $VT_DIR/INSTALL/grub/i386-pc/boot.img   || exit 1
     
     #copy other modules
-    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/i386-pc/ | egrep '\.(lst|mod)$' | while read line; do
+    ls -1 $VT_DIR/GRUB2/INSTALL/lib/grub/i386-pc/ | grep -E '\.(lst|mod)$' | while read line; do
         if ! echo $all_modules | grep -q " ${line%.mod} "; then
             echo "Copy $line ..."
             rm -f $VT_DIR/INSTALL/grub/i386-pc/$line

--- a/INSTALL/CreatePersistentImg.sh
+++ b/INSTALL/CreatePersistentImg.sh
@@ -95,7 +95,7 @@ else
     exit 1
 fi
 
-if [ "$outputdir" != "persistence.dat" ]; then
+if [ "$outputfile" != "persistence.dat" ]; then
     mkdir -p "$(dirname "$outputfile")"
 fi
 
@@ -107,9 +107,9 @@ freeloop=$(losetup -f)
 
 losetup $freeloop "$outputfile"
 
-if [ ! -z "$passphrase" ]; then
-    printf "$passphrase" | cryptsetup -q --verbose luksFormat $freeloop -
-    printf "$passphrase" | cryptsetup -q --verbose luksOpen $freeloop persist_decrypted -
+if [ -n "$passphrase" ]; then
+    printf '%s' "$passphrase" | cryptsetup -q --verbose luksFormat $freeloop -
+    printf '%s' "$passphrase" | cryptsetup -q --verbose luksOpen $freeloop persist_decrypted -
     _freeloop=$freeloop
     freeloop="/dev/mapper/persist_decrypted"
 fi
@@ -132,7 +132,7 @@ if [ -n "$config" ]; then
     rm -rf ./persist_tmp_mnt
 fi
 
-if [ ! -z "$passphrase" ]; then
+if [ -n "$passphrase" ]; then
     cryptsetup luksClose $freeloop
     freeloop=$_freeloop
 fi

--- a/INSTALL/ExtendPersistentImg.sh
+++ b/INSTALL/ExtendPersistentImg.sh
@@ -22,9 +22,9 @@ fi
 
 uid=$(id -u)
 if [ $uid -ne 0 ]; then
-    echo ""
-    echo "Please use sudo or run the script as root."
-    echo ""
+    echo "" >&2
+    echo "Please use sudo or run the script as root." >&2
+    echo "" >&2
     exit 1
 fi
 

--- a/INSTALL/ExtendPersistentImg.sh
+++ b/INSTALL/ExtendPersistentImg.sh
@@ -22,7 +22,9 @@ fi
 
 uid=$(id -u)
 if [ $uid -ne 0 ]; then
-    print_err "Please use sudo or run the script as root."
+    echo ""
+    echo "Please use sudo or run the script as root."
+    echo ""
     exit 1
 fi
 

--- a/INSTALL/Ventoy2Disk.sh
+++ b/INSTALL/Ventoy2Disk.sh
@@ -67,9 +67,8 @@ if [ -f mkexfatfs_static ]; then
         mv mkexfatfs mkexfatfs_shared
         mv mkexfatfs_static mkexfatfs
     else
-        if ./mkexfatfs -V > /dev/null 2>&1; then
-            echo "mkexfatfs can not run, check static version" >> ./log.txt
-        else
+        if ! ./mkexfatfs -V > /dev/null 2>&1; then
+            echo "mkexfatfs cannot run, check static version" >> ./log.txt
             if ./mkexfatfs_static -V > /dev/null 2>&1; then
                 echo "Use static version of mkexfatfs" >> ./log.txt
                 mv mkexfatfs mkexfatfs_shared
@@ -84,9 +83,9 @@ chmod +x -R ./tool/$TOOLDIR
 
 
 if [ -f /bin/bash ]; then
-    /bin/bash ./tool/VentoyWorker.sh $*
+    /bin/bash ./tool/VentoyWorker.sh "$@"
 else
-    ash ./tool/VentoyWorker.sh $*
+    ash ./tool/VentoyWorker.sh "$@"
 fi
 
 if [ -n "$OLDDIR" ]; then 

--- a/INSTALL/VentoyPlugson.sh
+++ b/INSTALL/VentoyPlugson.sh
@@ -122,7 +122,7 @@ if echo $DISK | grep -q "[a-z]d[a-z][1-9]"; then
     DISK=${DISK:0:-1}
 fi
 
-if echo $DISK | grep -E -q "/dev/nvme|/dev/mmcblk/dev/nbd"; then
+if echo "$DISK" | grep -E -q "/dev/nvme|/dev/mmcblk|/dev/nbd"; then
     if echo $DISK | grep -q "p[1-9]$"; then
         DISK=${DISK:0:-2}
     fi

--- a/INSTALL/all_in_one.sh
+++ b/INSTALL/all_in_one.sh
@@ -31,7 +31,7 @@ sh buildedk.sh >> $LOG 2>&1 || exit 1
 
 
 #
-# We almost rarely modifiy these code, so no need to build them everytime
+# We almost rarely modify these code, so no need to build them every time
 # If you want to rebuild them, just uncomment them.
 #
 

--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -377,7 +377,7 @@ elif [ "$MODE" = "install" -a -n "$NONDESTRUCTIVE" ]; then
     if [ $? -eq 0 ]; then
         if [ -z "$FORCE" ]; then
             vtwarn "$DISK already contains a Ventoy with version $version."
-            vtwarn "You can not do and don not need non-destructive installation."
+            vtwarn "You cannot do and do not need non-destructive installation."
             vtwarn ""
             exit 1
         fi

--- a/INSTALL/tool/create_ventoy_iso_part_dm.sh
+++ b/INSTALL/tool/create_ventoy_iso_part_dm.sh
@@ -33,6 +33,6 @@ if dmsetup -h > /dev/null 2>&1; then
         echo "Create /dev/mapper/$VPART success"
     fi    
 else
-    echo "dmsetup program not avaliable"
+    echo "dmsetup program not available"
     exit 1
 fi

--- a/INSTALL/tool/ventoy_lib.sh
+++ b/INSTALL/tool/ventoy_lib.sh
@@ -213,7 +213,7 @@ get_disk_ventoy_version() {
 wait_and_create_part() {
     vPART1=$1
     vPART2=$2
-    echo 'Wait for partitions $vPART1 and $vPART2 ...'
+    echo "Wait for partitions $vPART1 and $vPART2 ..."
     for i in 0 1 2 3 4 5 6 7 8 9; do
         if ls -l $vPART1 2>/dev/null | grep -q '^b'; then
             if ls -l $vPART2 2>/dev/null | grep -q '^b'; then

--- a/Plugson/pack.sh
+++ b/Plugson/pack.sh
@@ -1,12 +1,12 @@
 #!/bin/sh
 
 if [ -n "$PKG_DATE" ]; then
-    plugson_verion=$PKG_DATE
+    plugson_version=$PKG_DATE
 else
-    plugson_verion=$(date '+%Y%m%d %H:%M:%S')
+    plugson_version=$(date '+%Y%m%d %H:%M:%S')
 fi
 
-sed "s#.*plugson_build_date.*#                <b id=\"plugson_build_date\">$plugson_verion</b>#" -i ./www/index.html
+sed "s#.*plugson_build_date.*#                <b id=\"plugson_build_date\">$plugson_version</b>#" -i ./www/index.html
 
 if [ ! -f ./vs/VentoyPlugson/Release/VentoyPlugson.exe ]; then
     echo "NO VentoyPlugson.exe found"
@@ -36,7 +36,7 @@ done
 ls -1 ../INSTALL/grub/menu/ | while read line; do 
     echo -n ${line:0:5} >> ./www/menulist
 done 
-echo -n "$plugson_verion" > ./www/buildtime
+echo -n "$plugson_version" > ./www/buildtime
 
 tar cf www.tar www
 xz --check=crc32 www.tar

--- a/SQUASHFS/squashfs-tools-4.4/squashfs-tools/build.sh
+++ b/SQUASHFS/squashfs-tools-4.4/squashfs-tools/build.sh
@@ -24,9 +24,9 @@ else
     echo -e "\n========== FAILED ============\n"
 fi
 
-if uname -a | egrep -q 'x86_64|amd64'; then
+if uname -a | grep -E -q 'x86_64|amd64'; then
     name=unsquashfs_64
-elif uname -a | egrep -q 'aarch64'; then
+elif uname -a | grep -E -q 'aarch64'; then
     name=unsquashfs_aa64
 else
     name=unsquashfs_32

--- a/Vlnk/VentoyVlnk.sh
+++ b/Vlnk/VentoyVlnk.sh
@@ -29,7 +29,7 @@ if [ $uid -ne 0 ]; then
     exit 1
 fi
 
-#check system tools used bellow
+#check system tools used below
 for t in 'mountpoint' 'readlink' 'xzcat'; do
     if ! which "$t" > /dev/null 2>&1; then
         echo "$t command not found in current system!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '2'
-
 services:
   ventoy:
     build: .
     privileged: true
     volumes:
-     - .:/ventoy
+      - .:/ventoy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   ventoy:
     build: .
+    image: ventoy-ventoy
     privileged: true
     volumes:
       - .:/ventoy


### PR DESCRIPTION
## Summary

Improve and optimize code across CI, Docker, and shell scripts. This PR fixes several real bugs, updates outdated dependency versions, reduces Docker image size, and cleans up deprecated patterns.

### CI & Docker
- **ci.yml**: `actions/checkout` v3 → **v4**, add Docker Buildx + layer caching via `actions/cache@v4`
- **ci.yml**: use explicit `docker buildx build` with `--cache-from`/`--cache-to` flags so cache is actually wired to the build step
- **sync2gitee.yml**: pin `Yikun/hub-mirror-action` to **v1.5** (was `@master`)
- **Dockerfile**: chain `yum clean all && rm -rf /var/cache/yum` to reduce image size; use `WORKDIR` directive
- **docker-compose.yml**: remove deprecated `version` key (compose v2+ ignores it with a warning); pin image name for buildx compatibility

### Bug Fixes
- **VentoyPlugson.sh**: fix missing `|` separator in regex — `/dev/mmcblk` was concatenated with `/dev/nbd` instead of being an alternative
- **ventoy_lib.sh**: fix single-quoted string `'Wait for partitions $vPART1 and $vPART2 ...'` — variables were never expanded
- **CreatePersistentImg.sh**: fix wrong variable name `$outputdir` → `$outputfile` in directory creation guard
- **Ventoy2Disk.sh**: fix inverted `mkexfatfs` check logic — a successful run was logged as "cannot run"
- **Ventoy2Disk.sh**: use `"$@"` instead of `$*` for proper argument handling with spaces
- **ExtendPersistentImg.sh**: replace call to undefined `print_err` function with inline `echo >&2` (stderr)
- **CreatePersistentImg.sh**: use `printf '%s'` to avoid interpreting backslashes in passphrases

### Cleanups
- Replace deprecated `egrep` with `grep -E` across 6 build/install scripts
- **Plugson/pack.sh**: fix typo `plugson_verion` → `plugson_version`
- **FUSEISO/build.sh**: remove duplicate `strip --strip-all` call
- Fix typos: `avaliable` → `available`, `modifiy` → `modify`, `bellow` → `below`, `don not` → `do not`

## Review & Testing Checklist for Human
- [ ] Verify the `VentoyPlugson.sh` regex fix — ensure NVMe, mmcblk, and nbd device partition stripping works correctly
- [ ] Verify the `Ventoy2Disk.sh` mkexfatfs fallback logic — on a musl-libc system, test that the static binary is picked when the shared one fails
- [ ] Verify the `CreatePersistentImg.sh` output directory creation with a custom `-o /some/path/file.dat` argument
- [ ] Run a full Docker CI build to confirm the Dockerfile and compose changes work end-to-end

### Notes
- The Dockerfile doesn't `COPY` any repo files — the repo is volume-mounted at runtime. So the Dockerfile hash alone is sufficient for the layer cache key (no source changes can make the cached image stale)
- The busybox/initramfs scripts (`IMG/cpio/`, `LiveCD/`) still use `egrep` since those run in constrained busybox environments where `grep -E` may not be available
- The misspelled filenames `buidexfat.sh` / `buidlibfuse.sh` are left as-is because renaming would break cross-references in multiple scripts

Link to Devin session: https://app.devin.ai/sessions/dc804c5b843c4a6887a452ec732311cb
Requested by: @gfunkmonk