### PR TITLE
Fix MSVC warnings in vendored FatFs (C4319) and xz-embedded (C4267)

### DIFF
--- a/Plugson/src/Lib/xz-embedded/linux/lib/decompress_unxz.c
+++ b/Plugson/src/Lib/xz-embedded/linux/lib/decompress_unxz.c
@@ -302,7 +302,7 @@ int unxz(unsigned char *in, int in_size,
 		do {
 			if (b.in_pos == b.in_size && fill != NULL) {
 				if (in_used != NULL)
-					*in_used += b.in_pos;
+					*in_used += (int)b.in_pos;
 
 				b.in_pos = 0;
 
@@ -329,7 +329,7 @@ int unxz(unsigned char *in, int in_size,
 				 * returned by xz_dec_run(), but probably
 				 * it's not too bad.
 				 */
-				if (flush(b.out, b.out_pos) != (int)b.out_pos)
+				if (flush(b.out, (unsigned int)b.out_pos) != (int)b.out_pos)
 					ret = XZ_BUF_ERROR;
 
 				b.out_pos = 0;
@@ -344,7 +344,7 @@ int unxz(unsigned char *in, int in_size,
 	}
 
 	if (in_used != NULL)
-		*in_used += b.in_pos;
+		*in_used += (int)b.in_pos;
 
 	xz_dec_end(s);
 

--- a/Plugson/src/Lib/xz-embedded/linux/lib/xz/xz_dec_lzma2.c
+++ b/Plugson/src/Lib/xz-embedded/linux/lib/xz/xz_dec_lzma2.c
@@ -351,7 +351,7 @@ static bool dict_repeat(struct dictionary *dict, uint32_t *len, uint32_t dist)
 	if (dist >= dict->full || dist >= dict->size)
 		return false;
 
-	left = min_t(size_t, dict->limit - dict->pos, *len);
+	left = (uint32_t)min_t(size_t, dict->limit - dict->pos, *len);
 	*len -= left;
 
 	back = dict->pos - dist - 1;
@@ -385,7 +385,7 @@ static void dict_uncompressed(struct dictionary *dict, struct xz_buf *b,
 		if (copy_size > *left)
 			copy_size = *left;
 
-		*left -= copy_size;
+		*left -= (uint32_t)copy_size;
 
 		memcpy(dict->buf + dict->pos, b->in + b->in_pos, copy_size);
 		dict->pos += copy_size;
@@ -427,7 +427,7 @@ static uint32_t dict_flush(struct dictionary *dict, struct xz_buf *b)
 
 	dict->start = dict->pos;
 	b->out_pos += copy_size;
-	return copy_size;
+	return (uint32_t)copy_size;
 }
 
 /*****************
@@ -854,7 +854,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		if (tmp > s->lzma2.compressed - s->temp.size)
 			tmp = s->lzma2.compressed - s->temp.size;
 		if (tmp > in_avail)
-			tmp = in_avail;
+			tmp = (uint32_t)in_avail;
 
 		memcpy(s->temp.buf + s->temp.size, b->in + b->in_pos, tmp);
 
@@ -877,10 +877,10 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		if (!lzma_main(s) || s->rc.in_pos > s->temp.size + tmp)
 			return false;
 
-		s->lzma2.compressed -= s->rc.in_pos;
+		s->lzma2.compressed -= (uint32_t)s->rc.in_pos;
 
 		if (s->rc.in_pos < s->temp.size) {
-			s->temp.size -= s->rc.in_pos;
+			s->temp.size -= (uint32_t)s->rc.in_pos;
 			memmove(s->temp.buf, s->temp.buf + s->rc.in_pos,
 					s->temp.size);
 			return true;
@@ -907,7 +907,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 		if (in_avail > s->lzma2.compressed)
 			return false;
 
-		s->lzma2.compressed -= in_avail;
+		s->lzma2.compressed -= (uint32_t)in_avail;
 		b->in_pos = s->rc.in_pos;
 	}
 
@@ -917,7 +917,7 @@ static bool lzma2_lzma(struct xz_dec_lzma2 *s, struct xz_buf *b)
 			in_avail = s->lzma2.compressed;
 
 		memcpy(s->temp.buf, b->in + b->in_pos, in_avail);
-		s->temp.size = in_avail;
+		s->temp.size = (uint32_t)in_avail;
 		b->in_pos += in_avail;
 	}
 

--- a/Ventoy2Disk/Ventoy2Disk/ff14/source/ff.c
+++ b/Ventoy2Disk/Ventoy2Disk/ff14/source/ff.c
@@ -6166,7 +6166,7 @@ FRESULT f_mkfs (
 			b_data = b_fat + sz_fat * n_fat + sz_dir;	/* Data base */
 
 			/* Align data area to erase block boundary (for flash memory media) */
-			n = (DWORD)(((b_data + sz_blk - 1) & ~(sz_blk - 1)) - b_data);	/* Sectors to next nearest from current data base */
+			n = (DWORD)(((b_data + sz_blk - 1) & ~(LBA_t)(sz_blk - 1)) - b_data);	/* Sectors to next nearest from current data base */
 			if (fsty == FS_FAT32) {		/* FAT32: Move FAT */
 				sz_rsv += n; b_fat += n;
 			} else {					/* FAT: Expand FAT */


### PR DESCRIPTION
ff14/source/ff.c:6169 — sign-extension bug. `~(sz_blk - 1)` produces a 32-bit mask which is then AND'd with a 64-bit LBA_t. MSVC zero-extends the high bits, so the mask is wrong on the high half. Cast the operand to LBA_t before complementing so all high bits are correctly set.

xz-embedded/linux/lib/decompress_unxz.c and xz/xz_dec_lzma2.c — explicit narrowing casts at the points where size_t (host pointer arithmetic) is assigned to uint32_t / int (xz protocol fields). These were implicit truncations before; now the intent is documented at the call site.

No behavior change on either fix path — the masks and truncations are already what the code intends; this just suppresses the warnings and makes the intent explicit.

## Summary by Sourcery

Fix type-safety and alignment issues in vendored FatFs and xz-embedded code to eliminate MSVC warnings without changing runtime behavior.

Bug Fixes:
- Correct block alignment masking in FatFs by ensuring the erase block mask is computed using the full LBA_t width to avoid sign-extension issues.
- Add explicit narrowing casts in xz-embedded decompression paths where size_t values are assigned to 32-bit fields to make truncation intentional and resolve MSVC warnings.