### PR TITLE
Fix fdisk detection on BusyBox systems

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -186,7 +186,7 @@ if [ "$MODE" = "install" -a -z "$NONDESTRUCTIVE" ]; then
     else
         if parted -v > /dev/null 2>&1; then
             PARTTOOL='parted'            
-        elif fdisk -v >/dev/null 2>&1; then
+        elif command -v fdisk > /dev/null 2>&1; then
             PARTTOOL='fdisk'            
         else
             vterr "Both parted and fdisk are not found in the system, Ventoy can't create new partitions."


### PR DESCRIPTION
On BusyBox, fdisk -v exists but returns a non-zero exit code, causing the script to incorrectly conclude fdisk is not available. Use POSIX command -v instead to reliably check for fdisk.

## Summary by Sourcery

Bug Fixes:
- Fix detection of fdisk on BusyBox systems by using `command -v fdisk` instead of `fdisk -v`.