### PR TITLE
Replace mkexfatfs with mkfs.exfat in VentoyWorker.sh.

### DIFF
--- a/INSTALL/tool/VentoyWorker.sh
+++ b/INSTALL/tool/VentoyWorker.sh
@@ -314,16 +314,16 @@ if [ "$MODE" = "install" -a -z "$NONDESTRUCTIVE" ]; then
     wait_and_create_part ${PART1} ${PART2}    
     if [ -b ${PART1} ]; then
         vtinfo "Format partition 1 ${PART1} ..."
-        mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+        mkfs.exfat -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
         if [ $? -ne 0 ]; then
-            echo "mkexfatfs failed, now retry..."
-            mkexfatfs -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
+            echo "mkfs.exfat failed, now retry..."
+            mkfs.exfat -n "$VTNEW_LABEL" -s $cluster_sectors ${PART1}
             if [ $? -ne 0 ]; then
-                echo "######### mkexfatfs failed, exit ########"
+                echo "######### mkfs.exfat failed, exit ########"
                 exit 1
             fi
         else
-            echo "mkexfatfs success"
+            echo "mkfs.exfat success"
         fi        
     else
         vterr "${PART1} NOT exist"


### PR DESCRIPTION
mkexfatfs was provided by fuse-exfat-utils (exfat-utils), which has been deprecated since 2021 in favour of exfatprogs. exfatprogs ships mkfs.exfat instead, which is functionally identical and also available in the legacy package, making this change backward compatible.

## Summary by Sourcery

Replace use of the deprecated mkexfatfs utility with mkfs.exfat when formatting the first partition in VentoyWorker.sh to align with exfatprogs and maintain backward compatibility.